### PR TITLE
Fix relative path handling for .claude directory

### DIFF
--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -35,11 +35,23 @@ type MoveResult struct {
 
 func runMv(cmd *cobra.Command, args []string) error {
 	groupName := args[0]
-	fromPath := args[1]
-	toPath := args[2]
+	rawFromPath := args[1]
+	rawToPath := args[2]
+
+	// Validate and normalize the paths
+	fromPath, err := utils.ValidateAndNormalizePath(rawFromPath)
+	if err != nil {
+		return fmt.Errorf("invalid source path: %w", err)
+	}
+
+	toPath, err := utils.ValidateAndNormalizePath(rawToPath)
+	if err != nil {
+		return fmt.Errorf("invalid destination path: %w", err)
+	}
 
 	if verbose {
 		fmt.Printf("Loading configuration...\n")
+		fmt.Printf("Normalized paths: %s → %s\n", fromPath, toPath)
 	}
 
 	cfg, err := config.Load(cfgFile)

--- a/cmd/mv_test.go
+++ b/cmd/mv_test.go
@@ -64,7 +64,7 @@ func TestRunMv(t *testing.T) {
 	}{
 		{
 			name: "move existing file in multiple projects",
-			args: []string{"test-group", "old.md", "new.md"},
+			args: []string{"test-group", ".claude/old.md", ".claude/new.md"},
 			setupFiles: func() {
 				os.WriteFile(testFile1, []byte("test"), 0644)
 				os.WriteFile(testFile2, []byte("test"), 0644)
@@ -94,7 +94,7 @@ func TestRunMv(t *testing.T) {
 		},
 		{
 			name: "move directory",
-			args: []string{"test-group", "olddir", "newdir"},
+			args: []string{"test-group", ".claude/olddir", ".claude/newdir"},
 			setupFiles: func() {
 				os.MkdirAll(testDir, 0755)
 				os.WriteFile(filepath.Join(testDir, "nested.md"), []byte("nested"), 0644)
@@ -121,7 +121,7 @@ func TestRunMv(t *testing.T) {
 		},
 		{
 			name: "dry-run mode does not move",
-			args: []string{"test-group", "old.md", "new.md"},
+			args: []string{"test-group", ".claude/old.md", ".claude/new.md"},
 			setupFiles: func() {
 				os.WriteFile(testFile1, []byte("test"), 0644)
 				os.WriteFile(testFile2, []byte("test"), 0644)
@@ -151,7 +151,7 @@ func TestRunMv(t *testing.T) {
 		},
 		{
 			name: "move non-existent file succeeds with skip",
-			args: []string{"test-group", "nonexistent.md", "new.md"},
+			args: []string{"test-group", ".claude/nonexistent.md", ".claude/new.md"},
 			setupFiles: func() {
 				// No files to create
 			},
@@ -167,7 +167,7 @@ func TestRunMv(t *testing.T) {
 		},
 		{
 			name: "move with destination already exists",
-			args: []string{"test-group", "old.md", "existing.md"},
+			args: []string{"test-group", ".claude/old.md", ".claude/existing.md"},
 			setupFiles: func() {
 				os.WriteFile(testFile1, []byte("old"), 0644)
 				existingFile := filepath.Join(project1, "existing.md")
@@ -195,7 +195,7 @@ func TestRunMv(t *testing.T) {
 		},
 		{
 			name: "invalid group name returns error",
-			args: []string{"nonexistent-group", "old.md", "new.md"},
+			args: []string{"nonexistent-group", ".claude/old.md", ".claude/new.md"},
 			setupFiles: func() {
 				// No setup needed
 			},
@@ -441,7 +441,7 @@ func TestMvCommandFlags(t *testing.T) {
 			cfgFile = configPath
 
 			// Run command
-			err := runMv(nil, []string{"test", "old.md", "new.md"})
+			err := runMv(nil, []string{"test", ".claude/old.md", ".claude/new.md"})
 			if err != nil {
 				t.Errorf("runMv() unexpected error: %v", err)
 			}

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -31,10 +31,17 @@ type deleteTarget struct {
 
 func runRm(cmd *cobra.Command, args []string) error {
 	groupName := args[0]
-	targetPath := args[1]
+	rawPath := args[1]
+
+	// Validate and normalize the path
+	targetPath, err := utils.ValidateAndNormalizePath(rawPath)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
 
 	if verbose {
 		fmt.Printf("Loading configuration...\n")
+		fmt.Printf("Normalized path: %s\n", targetPath)
 	}
 
 	cfg, err := config.Load(cfgFile)

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -64,7 +64,7 @@ func TestRunRm(t *testing.T) {
 	}{
 		{
 			name: "delete existing file from multiple projects",
-			args: []string{"test-group", "test.md"},
+			args: []string{"test-group", ".claude/test.md"},
 			setupFiles: func() {
 				os.WriteFile(testFile1, []byte("test"), 0644)
 				os.WriteFile(testFile2, []byte("test"), 0644)
@@ -85,7 +85,7 @@ func TestRunRm(t *testing.T) {
 		},
 		{
 			name: "delete directory recursively",
-			args: []string{"test-group", "testdir"},
+			args: []string{"test-group", ".claude/testdir"},
 			setupFiles: func() {
 				os.MkdirAll(testDir, 0755)
 				os.WriteFile(filepath.Join(testDir, "nested.md"), []byte("nested"), 0644)
@@ -103,7 +103,7 @@ func TestRunRm(t *testing.T) {
 		},
 		{
 			name: "dry-run mode does not delete",
-			args: []string{"test-group", "test.md"},
+			args: []string{"test-group", ".claude/test.md"},
 			setupFiles: func() {
 				os.WriteFile(testFile1, []byte("test"), 0644)
 				os.WriteFile(testFile2, []byte("test"), 0644)
@@ -124,7 +124,7 @@ func TestRunRm(t *testing.T) {
 		},
 		{
 			name: "delete non-existent file succeeds with skip",
-			args: []string{"test-group", "nonexistent.md"},
+			args: []string{"test-group", ".claude/nonexistent.md"},
 			setupFiles: func() {
 				// No files to create
 			},
@@ -140,7 +140,7 @@ func TestRunRm(t *testing.T) {
 		},
 		{
 			name: "invalid group name returns error",
-			args: []string{"nonexistent-group", "test.md"},
+			args: []string{"nonexistent-group", ".claude/test.md"},
 			setupFiles: func() {
 				// No setup needed
 			},
@@ -314,7 +314,7 @@ func TestRmCommandFlags(t *testing.T) {
 			cfgFile = configPath
 
 			// Run command
-			err := runRm(nil, []string{"test", "test.md"})
+			err := runRm(nil, []string{"test", ".claude/test.md"})
 			if err != nil {
 				t.Errorf("runRm() unexpected error: %v", err)
 			}


### PR DESCRIPTION
When users copy paths from their editor (e.g., .claude/commands/foo.md), the tool now automatically removes the .claude/ prefix and validates that paths start with .claude/.

Changes:
- Add ValidateAndNormalizePath() utility function
- Update rm and mv commands to validate and normalize paths
- Paths must start with .claude/ (auto-removed after validation)
- Prevent parent directory traversal (..) and absolute paths
- Update all test cases to use .claude/ prefix
- Add comprehensive test coverage for path validation

Example usage:
  dot-claude-sync rm my-group .claude/commands/foo.md dot-claude-sync mv my-group .claude/old.md .claude/new.md