### PR TITLE
Add short command alias for dot-claude-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 claude-sync
 dot-claude-sync
+/dcs
 *.exe
 *.exe~
 *.dll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,17 @@ claude-sync is a CLI tool that synchronizes `.claude` directories across multipl
 
 **Option 1: Install via `go install` (Recommended)**
 ```bash
+# Install the main binary (dot-claude-sync)
 go install github.com/yugo-ibuki/dot-claude-sync@latest
+
+# Optionally install the shorter alias (dcs)
+go install github.com/yugo-ibuki/dot-claude-sync/cmd/dcs@latest
 ```
 This installs the binary to `$GOPATH/bin` (usually `~/go/bin`).
+
+**Command Aliases**:
+- `dot-claude-sync`: Full command name
+- `dcs`: Short alias (both work identically)
 
 **Option 2: Build from source**
 ```bash
@@ -55,14 +63,19 @@ Download from GitHub Releases (if available).
 ### For Development
 
 ```bash
-# Build the binary
+# Build the main binary
 go build -o dot-claude-sync
 
-# Install locally to $GOPATH/bin
+# Build the short alias
+go build -o dcs ./cmd/dcs
+
+# Install both to $GOPATH/bin
 go install
+go install ./cmd/dcs
 
 # Run directly without building
 go run main.go <command>
+go run ./cmd/dcs/main.go <command>  # or using dcs entry point
 
 # Run with specific command
 go run main.go init
@@ -74,7 +87,7 @@ go mod tidy
 go mod verify
 ```
 
-**Important**: Build artifacts (`dot-claude-sync`, `claude-sync`) are excluded from git via `.gitignore`. Do not commit binaries to the repository.
+**Important**: Build artifacts (`dot-claude-sync`, `dcs`, `claude-sync`) are excluded from git via `.gitignore`. Do not commit binaries to the repository.
 
 ## Architecture
 
@@ -82,7 +95,8 @@ go mod verify
 
 The project uses `github.com/spf13/cobra` for CLI commands:
 
-- **main.go**: Entry point that calls `cmd.Execute()`
+- **main.go**: Entry point for `dot-claude-sync` that calls `cmd.Execute()`
+- **cmd/dcs/main.go**: Entry point for `dcs` alias (same functionality as main.go)
 - **cmd/root.go**: Root command with global flags (`--config`, `--dry-run`, `--verbose`, `--force`)
 - **cmd/init.go**: Interactive configuration file creation
 - **cmd/push.go**: File synchronization across projects (TODO: implementation pending)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,22 @@ However, modern CLI Agent workflows increasingly rely on **git worktrees** to ma
 ## Installation
 
 ```bash
+# Install the main binary
 go install github.com/yugo-ibuki/dot-claude-sync@latest
+
+# Optionally install the shorter alias
+go install github.com/yugo-ibuki/dot-claude-sync/cmd/dcs@latest
 ```
+
+**Command Aliases**: Both `dot-claude-sync` and `dcs` work identically.
 
 Or build from source:
 
 ```bash
 git clone https://github.com/yugo-ibuki/dot-claude-sync.git
 cd dot-claude-sync
-go build
+go build                    # builds dot-claude-sync
+go build -o dcs ./cmd/dcs   # builds dcs alias
 ```
 
 ## Quick Start
@@ -39,6 +46,8 @@ Run the init command to create your configuration file:
 
 ```bash
 dot-claude-sync init
+# or using the short alias
+dcs init
 ```
 
 This will interactively guide you through creating `~/.config/dot-claude-sync/config.yaml`.
@@ -70,6 +79,8 @@ groups:
 ```bash
 # Sync all projects in the web-projects group
 dot-claude-sync push web-projects
+# or
+dcs push web-projects
 ```
 
 This distributes `.claude` directory contents across all projects based on priority settings.
@@ -85,6 +96,8 @@ This distributes `.claude` directory contents across all projects based on prior
 | `dot-claude-sync mv <group> <from> <to>` | Move/rename files in all projects |
 | `dot-claude-sync list [group]` | Show groups or group details |
 | `dot-claude-sync config <subcommand>` | Manage configuration (add/remove groups and projects) |
+
+**Note**: All commands can use `dcs` instead of `dot-claude-sync` (e.g., `dcs init`, `dcs push <group>`).
 
 ## Features
 

--- a/cmd/dcs/main.go
+++ b/cmd/dcs/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yugo-ibuki/dot-claude-sync/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Add a short command alias 'dcs' that works identically to 'dot-claude-sync'. This provides a more convenient way to invoke the CLI tool while maintaining backward compatibility with the original command name.

Changes:
- Add cmd/dcs/main.go entry point for dcs binary
- Update .gitignore to exclude /dcs binary at root
- Update installation docs in README.md and CLAUDE.md
- Add usage examples for both command names